### PR TITLE
Adapted addon to use a better provider for Japanese subs

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ function withRateLimit(fn) {
 // --- Helper Function to Fetch and Select Subtitle ---
 async function fetchAndSelectSubtitle(languageId, baseSearchParams) {
     const searchParams = { ...baseSearchParams, sublanguageid: languageId };
-    const searchUrl = buildSearchUrl(searchParams)
+    const searchUrl = buildSearchUrl(searchParams);
     console.log(`Searching ${languageId} subtitles at: ${searchUrl}`);
 
     try {


### PR DESCRIPTION
- Added type to the `baseSearchParams` object
- When requesting a Japanese subtitle, the [Buta no Subs addon](https://github.com/Pigamer37/buta-no-subs-stremio-addon) will be used instead of OpenSubtitle (which lacks jpn subs more often than not)

This implements the second option described in my comment on issue #5.

If merged:
- I'd be okay with providing the support, as I'm the Buta no Subs addon developer
- I'd appreciate credit for the Buta no Subs addon on the README 
- This PR would probably close #5 