### PR TITLE
Fixes a bug that was sometimes generating invalid merged SRTs

### DIFF
--- a/index.js
+++ b/index.js
@@ -642,7 +642,9 @@ function mergeSubtitles(mainSubs, transSubs, mergeThresholdMs = 500) {
         });
         // console.log("After main sanitize:", cleanMainText.substring(0, 50));
         // Flatten main text by replacing newlines with spaces
-        const flatMainText = cleanMainText.replace(/\r?\n|\r/g, ' ');
+        const flatMainText = cleanMainText.replace(/\r?\n|\r/g, ' ').trim();
+
+        let mergedText = flatMainText;
         if (bestMatchIndex !== -1) {
             const bestTransSub = transSubs[bestMatchIndex];
             // console.log("Before trans sanitize:", bestTransSub.text.substring(0, 50));
@@ -652,20 +654,19 @@ function mergeSubtitles(mainSubs, transSubs, mergeThresholdMs = 500) {
             });
             // console.log("After trans sanitize:", cleanTransText.substring(0, 50));
             // Flatten translation text by replacing newlines with spaces
-            const flatTransText = cleanTransText.replace(/\r?\n|\r/g, ' ');
-
-            mergedSubs.push({
-                ...mainSub, // Keep main timing and ID
-                // Combine flattened texts with a newline, keeping translation italic
-                text: `${flatMainText}\n<i>${flatTransText}</i>`
-            });
-        } else {
-            // If no suitable translation match found, add the main subtitle as is (also flattened)
-            mergedSubs.push({
-                 ...mainSub,
-                 text: flatMainText
-            });
+            const flatTransText = cleanTransText.replace(/\r?\n|\r/g, ' ').trim();
+            if (flatTransText) {
+                mergedText = (flatMainText + '\n<i>' + flatTransText + '</i>').trim();
+            }
         }
+
+        // Skip empty cues
+        if (!mergedText) continue;
+
+        mergedSubs.push({
+            ...mainSub,
+            text: mergedText
+        });
     }
     console.log(`Finished merging. Result has ${mergedSubs.length} entries.`);
     return mergedSubs;


### PR DESCRIPTION
If the main language had an empty prompt (a single newline character) for a timestamp, but the translated language had a prompt there, the merge would look something like:

```
103
00:10:53,405 --> 00:10:54,155

<i>De acuerdo.</i>
```
...which is invalid (there's a newline between the timestamp and the text). This actually happened in one of the Avengers Endgame merges I was testing 😅

This patch fixes that just by trimming whitespace in each version's string before and after merging.