### PR TITLE
Added in more deprecated language codes, plus lang priority order

### DIFF
--- a/index.js
+++ b/index.js
@@ -271,39 +271,94 @@ async function fetchAllSubtitles(baseSearchParams, type, videoParams = {}, needs
 // Languages with multiple ISO 639-2 codes (bibliographic B / terminological T)
 // When user selects either code, match both in results
 const languageAliases = {
-    'alb': ['alb', 'sqi'], 'sqi': ['alb', 'sqi'],  // Albanian
-    'arm': ['arm', 'hye'], 'hye': ['arm', 'hye'],  // Armenian
-    'baq': ['baq', 'eus'], 'eus': ['baq', 'eus'],  // Basque
-    'bur': ['bur', 'mya'], 'mya': ['bur', 'mya'],  // Burmese
-    'chi': ['chi', 'zho'], 'zho': ['chi', 'zho'],  // Chinese
-    'cze': ['cze', 'ces'], 'ces': ['cze', 'ces'],  // Czech
-    'dut': ['dut', 'nld'], 'nld': ['dut', 'nld'],  // Dutch
-    'fre': ['fre', 'fra'], 'fra': ['fre', 'fra'],  // French
-    'geo': ['geo', 'kat'], 'kat': ['geo', 'kat'],  // Georgian
-    'ger': ['ger', 'deu'], 'deu': ['ger', 'deu'],  // German
-    'gre': ['gre', 'ell'], 'ell': ['gre', 'ell'],  // Greek
-    'ice': ['ice', 'isl'], 'isl': ['ice', 'isl'],  // Icelandic
-    'mac': ['mac', 'mkd'], 'mkd': ['mac', 'mkd'],  // Macedonian
-    'may': ['may', 'msa'], 'msa': ['may', 'msa'],  // Malay
-    'mao': ['mao', 'mri'], 'mri': ['mao', 'mri'],  // Maori
-    'per': ['per', 'fas'], 'fas': ['per', 'fas'],  // Persian
-    'rum': ['rum', 'ron'], 'ron': ['rum', 'ron'],  // Romanian
-    'slo': ['slo', 'slk'], 'slk': ['slo', 'slk'],  // Slovak
-    'tib': ['tib', 'bod'], 'bod': ['tib', 'bod'],  // Tibetan
-    'wel': ['wel', 'cym'], 'cym': ['wel', 'cym'],  // Welsh
+    'aka': ['aka', 'fat', 'twi'],         // Akan (with fallbacks)
+    'fat': ['fat', 'aka', 'twi'],         // Akan-Fanti (with fallbacks)
+    'twi': ['twi', 'aka', 'fat'],         // Akan-Twi (with fallbacks)
+    'alb': ['alb', 'sqi'],                // Albanian (with fallback)
+    'sqi': ['sqi', 'alb'],                // Albanian (with fallback)
+    'ara': ['ara', 'arb'],                // Arabic (with fallback)
+    'arb': ['arb', 'ara'],                // Arabic (with fallback)
+    'arm': ['arm', 'xcl', 'hye', 'hyw'],  // Armenian (with fallbacks)
+    'xcl': ['xcl', 'arm', 'hye', 'hyw'],  // Armanian-Classical (with fallbacks)
+    'hye': ['hye', 'arm', 'hyw', 'xcl'],  // Armenian-Eastern (with fallbacks)
+    'hyw': ['hyw', 'arm', 'hye', 'xcl'],  // Armenian-Western (with fallbacks)
+    'baq': ['baq', 'eus'],                // Basque (with fallback)
+    'eus': ['eus', 'baq'],                // Basque (with fallback)
+    'bur': ['bur', 'mya'],                // Burmese (with fallback)
+    'mya': ['mya', 'bur'],                // Burmese (with fallback)
+    'chi': ['chi', 'zho'],                // Chinese (with fallback)
+    'zho': ['zho', 'chi'],                // Chinese (with fallback)
+    'ces': ['ces', 'cze'],                // Czech (with fallback)
+    'cze': ['cze', 'ces'],                // Czech (with fallback)
+    'dut': ['dut', 'nld'],                // Dutch (with fallback)
+    'nld': ['nld', 'dut'],                // Dutch (with fallback)
+    'fil': ['fil', 'tgl'],                // Filipino (Pilipino) (with fallback)
+    'tgl': ['tgl', 'fil'],                // Filipino-Tagalog (with fallback)
+    'fra': ['fra', 'fre'],                // French (with fallback)
+    'fre': ['fre', 'fra'],                // French (with fallback)
+    'geo': ['geo', 'kat'],                // Georgian (with fallback)
+    'kat': ['kat', 'geo'],                // Georgian (with fallback)
+    'deu': ['deu', 'ger'],                // German (with fallback)
+    'ger': ['ger', 'deu'],                // German (with fallback)
+    'ell': ['ell', 'gre'],                // Greek (with fallback)
+    'gre': ['gre', 'ell'],                // Greek (with fallback)
+    'ice': ['ice', 'isl'],                // Icelandic (with fallback)
+    'isl': ['isl', 'ice'],                // Icelandic (with fallback)
+    'ind': ['ind', 'msa', 'may'],         // Indonesian (with fallback)
+    'mac': ['mac', 'mkd'],                // Macedonian (with fallback)
+    'mkd': ['mkd', 'mac'],                // Macedonian (with fallback)
+    'msa': ['msa', 'ind', 'may'],         // Malay (with fallback)
+    'may': ['may', 'ind', 'msa'],         // Malay (with fallback)
+    'mao': ['mao', 'mri'],                // Maori (with fallback)
+    'mri': ['mri', 'mao'],                // Maori (with fallback)
+    'nor': ['nor', 'nob', 'nno'],         // Norwegian (with fallbacks)
+    'nob': ['nob', 'nor', 'nno'],         // Norwegian-Bokmål (with fallbacks)
+    'nno': ['nno', 'nor', 'nob'],         // Norwegian-Nynorsk (with fallbacks)
+    'osd': ['osd', 'oss'],                // Ossetian-Digor (with fallback)
+    'oss': ['oss', 'osd'],                // Ossetian-Ossetic (with fallback)
+    'fas': ['fas', 'per'],                // Persian (with fallback)
+    'per': ['per', 'fas'],                // Persian (with fallback)
+    'ron': ['ron', 'rum', 'mol'],         // Romanian (with fallback)
+    'rum': ['rum', 'ron', 'mol'],         // Romanian (with fallback)
+    'mol': ['mol', 'rum', 'ron'],         // Romanian-Moldavian (with fallback)
+    'scc': ['scc', 'srp'],                // Serbian (with fallback)
+    'srp': ['srp', 'scc'],                // Serbian (with fallback)
+    'slk': ['slk', 'slo'],                // Slovak (with fallback)
+    'slo': ['slo', 'slk'],                // Slovak (with fallback)
+    'bod': ['bod', 'tib'],                // Tibetan (with fallback)
+    'tib': ['tib', 'bod'],                // Tibetan (with fallback)
+    'cym': ['cym', 'wel'],                // Welsh (with fallback)
+    'wel': ['wel', 'cym']                 // Welsh (with fallback)
 };
 
 function filterSubtitlesByLanguage(allSubtitles, languageId) {
     if (!allSubtitles) return null;
 
     // Check for language aliases (e.g., Romanian: rum/ron)
+    // The order in the alias array represents preference - first code is most preferred
     const codesToMatch = languageAliases[languageId] || [languageId];
     const langSubs = allSubtitles.filter(sub => codesToMatch.includes(sub.lang));
-    
+
     if (langSubs.length === 0) {
         console.log(`No subtitles found for language ${languageId}.`);
         return null;
     }
+
+    // Sort by preferred language code order, then by downloads within each code
+    langSubs.sort((a, b) => {
+        const aCodeIndex = codesToMatch.indexOf(a.lang);
+        const bCodeIndex = codesToMatch.indexOf(b.lang);
+
+        // First, sort by language code preference (lower index = higher preference)
+        if (aCodeIndex !== bCodeIndex) {
+            return aCodeIndex - bCodeIndex;
+        }
+
+        // Within the same language code, sort by downloads (higher = better)
+        const aDownloads = a.downloads || 0;
+        const bDownloads = b.downloads || 0;
+        return bDownloads - aDownloads;
+    });
 
     // Map to the desired return format
     const subtitleList = langSubs.map((sub, idx) => {


### PR DESCRIPTION
Added in more deprecated language codes, and treat alternates in order of preferred match. 

eg: if the user wants `nob` (Norwegian-Bokmål) then we would like to return Norwegian-Bokmål to them if possible, but if there's no subtitles for `nob`, then second choice is `nor` (Norwegian), then finally if that still isn't available we try to return `nno` (Norwegian-Nynorsk). This is done with dialects / microlanguage sets, because we're hoping that similar dialects are more likely to be understood. Orders can be easily changed if needed by just modifying the array value orders.