### PR TITLE
Verify that the decoded language is the one we expect before merging

### DIFF
--- a/encoding.js
+++ b/encoding.js
@@ -73,7 +73,8 @@ const ISO639_3_TO_1 = {
     'tgl': 'tl', 'tha': 'th', 'vie': 'vi',
 
     // East Asian variants
-    'zht': 'zh', 'zhc': 'zh', 'zhe': 'zh',
+    'zht': 'zh', 'zhc': 'zh',  // Note: 'zhe' (bilingual Chinese-English) intentionally omitted
+
     // Central Asian languages
     'kaz': 'kk', 'kir': 'ky', 'mon': 'mn', 'tuk': 'tk', 'uzb': 'uz',
 
@@ -871,6 +872,12 @@ function decodeSubtitleBuffer(buffer, languageHint = null, options = {}) {
     }
 
     const log = silent ? () => {} : console.log.bind(console);
+
+    // Check if this language code should be skipped entirely
+    if (languageHint && SKIP_LANGUAGE_CODES.includes(languageHint.toLowerCase())) {
+        log(`[ENCODING] Skipping '${languageHint}' - language code is in skip list`);
+        return null;
+    }
 
     // Normalize language hint to 2-letter code (accepts both 2 and 3 letter codes)
     languageHint = normalizeLanguageCode(languageHint);

--- a/encoding.js
+++ b/encoding.js
@@ -279,7 +279,7 @@ const FRANC_TO_ISO2 = {
  *    at least get something useful back.
  * Each language maps to an array of its related languages.
  * Do not add items here just because they "look" the same or have the same character set! This is
- * only for nearly interchangeable and bidirectionally understandable languages.
+ * only for nearly interchangeable and bidirectionally understandable written languages.
  */
 const RELATED_LANGUAGES = {
     // South Slavic (Latin script) - very high mutual intelligibility
@@ -291,34 +291,24 @@ const RELATED_LANGUAGES = {
     'me': ['bs', 'hr', 'sr', 'sl'],   // Montenegrin
 
     // West Slavic
-    'cs': ['sk', 'pl'],         // Czech
-    'sk': ['cs', 'pl'],         // Slovak
-    'pl': ['cs', 'sk'],         // Polish
+    'cs': ['sk'],               // Czech
+    'sk': ['cs'],               // Slovak
 
     // Scandinavian
     'da': ['no', 'sv'],         // Danish
     'no': ['da', 'sv'],         // Norwegian
     'sv': ['da', 'no'],         // Swedish
 
-    // Finno-Ugric
-    'fi': ['et'],               // Finnish
-    'et': ['fi'],               // Estonian
-
     // Iberian/Romance
-    'es': ['pt', 'ca', 'gl'],   // Spanish
-    'pt': ['es', 'gl'],         // Portuguese
-    'ca': ['es', 'oc'],         // Catalan (related to Occitan)
-    'gl': ['es', 'pt'],         // Galician
+    'pt': ['gl'],               // Portuguese
+    'gl': ['pt'],               // Galician
+
+    'ca': ['oc'],               // Catalan (related to Occitan)
     'oc': ['ca'],               // Occitan (related to Catalan)
 
     // Malay-Indonesian
     'id': ['ms'],               // Indonesian
-    'ms': ['id'],               // Malay
-
-    // East Slavic (Cyrillic)
-    'ru': ['uk', 'be'],         // Russian
-    'uk': ['ru', 'be'],         // Ukrainian
-    'be': ['ru', 'uk'],         // Belarusian
+    'ms': ['id']                // Malay
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -448,6 +448,7 @@ async function fetchSubtitleContent(url, sourceFormat = 'srt', languageCode = nu
             timeout: 15000,
             maxContentLength: 5 * 1024 * 1024  // 5 MB limit
         });
+        console.log(`Successfully fetched subtitle: ${url}`);
 
         const buffer = Buffer.from(response.data);
 
@@ -462,8 +463,11 @@ async function fetchSubtitleContent(url, sourceFormat = 'srt', languageCode = nu
         // legacy encodings via chardet (Windows-1251, ISO-8859-x, etc.), and
         // double-encoded UTF-8 text (e.g., Thai/CJK/Cyrillic showing as mojibake).
         const subtitleText = decodeSubtitleBuffer(buffer, languageCode);
+        if (!subtitleText) {
+            console.error(`Decoding/validation failed (possibly wrong language or encoding issue)`);
+            return null;
+        }
 
-        console.log(`Successfully fetched subtitle: ${url}`);
         return subtitleText;
 
     } catch (error) {
@@ -514,6 +518,7 @@ async function fetchSubtitleContentOldAPI(url, sourceFormat = 'srt', cookie = nu
             headers: headers,
             maxContentLength: 5 * 1024 * 1024  // 5 MB limit
         });
+        console.log(`Successfully fetched subtitle: ${url}`);
 
         let contentBuffer = Buffer.from(response.data);
         let subtitleText;
@@ -541,6 +546,10 @@ async function fetchSubtitleContentOldAPI(url, sourceFormat = 'srt', cookie = nu
         // legacy encodings via chardet (Windows-1251, ISO-8859-x, etc.), and
         // double-encoded UTF-8 text (e.g., Thai/CJK/Cyrillic showing as mojibake).
         subtitleText = decodeSubtitleBuffer(contentBuffer, languageCode);
+        if (!subtitleText) {
+            console.error(`Decoding/validation failed (possibly wrong language or encoding issue)`);
+            return null;
+        }
 
         // 3. Convert to SRT if needed
         if (sourceFormat.toLowerCase() !== 'srt') {

--- a/index.js
+++ b/index.js
@@ -816,7 +816,8 @@ process.on('SIGINT', () => {
                  }
                  // Log the text of the first parsed subtitle entry, if it exists
                  if (subtitles.length > 0) {
-                     console.log(`First parsed subtitle text by SRTParser2: [${subtitles[0].text}]`);
+                     const firstText = subtitles[0].text.replace(/[\r\n]+/g, ' ');
+                     console.log(`First parsed subtitle text by SRTParser2: [${firstText}]`);
                  } else {
                      console.log("SRTParser2 returned an empty array.");
                  }

--- a/index.js
+++ b/index.js
@@ -968,12 +968,13 @@ process.on('SIGINT', () => {
                     console.log(`Attempting to process main subtitle: ID=${mainSubInfo.id}, Downloads=${mainSubInfo.downloads}`);
                     
                     // Use old API fetch if format is not SRT (indicates old API source)
-                    // Pass mainLang for encoding detection hints
+                    // Pass the actual language code from API response (not user's requested code)
+                    // This ensures proper encoding detection even when user requested an alias
                     let mainSubContent;
                     if (mainSubInfo.format && mainSubInfo.format.toLowerCase() !== 'srt') {
-                        mainSubContent = await fetchSubtitleContentOldAPI(mainSubInfo.url, mainSubInfo.format, cookie, false, mainLang);
+                        mainSubContent = await fetchSubtitleContentOldAPI(mainSubInfo.url, mainSubInfo.format, cookie, false, mainSubInfo.lang);
                     } else {
-                        mainSubContent = await fetchSubtitleContent(mainSubInfo.url, mainSubInfo.format, mainLang);
+                        mainSubContent = await fetchSubtitleContent(mainSubInfo.url, mainSubInfo.format, mainSubInfo.lang);
                     }
                     if (!mainSubContent) {
                         console.warn(`Failed to fetch content for main sub ID ${mainSubInfo.id}. Trying next candidate.`);
@@ -1013,12 +1014,13 @@ process.on('SIGINT', () => {
                     console.log(`Processing translation candidate v${version} (ID: ${transSubInfo.id})...`);
 
                     // Use old API fetch if format is not SRT (indicates old API source)
-                    // Pass transLang for encoding detection hints
+                    // Pass the actual language code from API response (not user's requested code)
+                    // This ensures proper encoding detection even when user requested an alias
                     let transSubContent;
                     if (transSubInfo.format && transSubInfo.format.toLowerCase() !== 'srt') {
-                        transSubContent = await fetchSubtitleContentOldAPI(transSubInfo.url, transSubInfo.format, cookie, false, transLang);
+                        transSubContent = await fetchSubtitleContentOldAPI(transSubInfo.url, transSubInfo.format, cookie, false, transSubInfo.lang);
                     } else {
-                        transSubContent = await fetchSubtitleContent(transSubInfo.url, transSubInfo.format, transLang);
+                        transSubContent = await fetchSubtitleContent(transSubInfo.url, transSubInfo.format, transSubInfo.lang);
                     }
                     if (!transSubContent) {
                         console.warn(`Failed to fetch content for translation v${version}. Skipping.`);

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ const languageMap = {
     'swe': 'Swedish', 'syr': 'Syriac', 'tam': 'Tamil', 'tat': 'Tatar', 'tel': 'Telugu', 'tet': 'Tetum',
     'tgl': 'Tagalog', 'tha': 'Thai', 'tok': 'Toki Pona', 'tur': 'Turkish', 'tuk': 'Turkmen', 'ukr': 'Ukrainian',
     'urd': 'Urdu', 'uzb': 'Uzbek', 'vie': 'Vietnamese', 'wel': 'Welsh', 'wen': 'Sorbian languages',
-    'zhc': 'Chinese (Cantonese)', 'zhe': 'Chinese bilingual', 'zht': 'Chinese (traditional)'
+    'zhc': 'Chinese (Cantonese)', 'zht': 'Chinese (traditional)'
 };
 
 // Map ISO 639-1 (browser) language codes to ISO 639-3 (our system) language codes

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,10 @@
         "chardet": "^2.1.0",
         "dotenv": "^17.2.3",
         "express": "^4.18.2",
+        "franc": "^6.2.0",
+        "franc-all": "^7.2.0",
         "iconv-lite": "^0.6.3",
+        "iso-639-3": "^3.0.1",
         "pako": "^2.1.0",
         "sanitize-html": "^2.17.0",
         "srt-parser-2": "^1.2.3",
@@ -389,6 +392,16 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
       "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
       "license": "ISC"
+    },
+    "node_modules/collapse-white-space": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
+      "integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
@@ -872,6 +885,32 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/franc": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/franc/-/franc-6.2.0.tgz",
+      "integrity": "sha512-rcAewP7PSHvjq7Kgd7dhj82zE071kX5B4W1M4ewYMf/P+i6YsDQmj62Xz3VQm9zyUzUXwhIde/wHLGCMrM+yGg==",
+      "license": "MIT",
+      "dependencies": {
+        "trigram-utils": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/franc-all": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/franc-all/-/franc-all-7.2.0.tgz",
+      "integrity": "sha512-ZR6ciLQTDBaOvBdkOd8+vqDzaLtmIXRa9GCzcAlaBpqNAKg9QrtClPmqiKac5/xZXfCZGMo1d8dIu1T0BLhHEg==",
+      "license": "MIT",
+      "dependencies": {
+        "trigram-utils": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -1151,6 +1190,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/iso-639-3": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/iso-639-3/-/iso-639-3-3.0.1.tgz",
+      "integrity": "sha512-SdljCYXOexv/JmbQ0tvigHN43yECoscVpe2y2hlEqy/CStXQlroPhZLj7zKLRiGqLJfw8k7B973UAMDoQczVgQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/joi-browser": {
       "version": "13.4.0",
       "resolved": "https://registry.npmjs.org/joi-browser/-/joi-browser-13.4.0.tgz",
@@ -1282,6 +1331,16 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==",
       "license": "ISC"
+    },
+    "node_modules/n-gram": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/n-gram/-/n-gram-2.0.2.tgz",
+      "integrity": "sha512-S24aGsn+HLBxUGVAUFOwGpKs7LBcG4RudKU//eWzt/mQ97/NMKQxDWHyHx63UNWk/OOdihgmzoETn1tf5nQDzQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -2102,6 +2161,20 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/trigram-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/trigram-utils/-/trigram-utils-2.0.1.tgz",
+      "integrity": "sha512-nfWIXHEaB+HdyslAfMxSqWKDdmqY9I32jS7GnqpdWQnLH89r6A5sdk3fDVYqGAZ0CrT8ovAFSAo6HRiWcWNIGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "collapse-white-space": "^2.0.0",
+        "n-gram": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -10,19 +10,22 @@
     "test:e2e": "node test/e2e.test.js"
   },
   "dependencies": {
-    "axios": "^1.9.0",
-    "stremio-addon-sdk": "^1.6.10",
-    "srt-parser-2": "^1.2.3",
-    "pako": "^2.1.0",
-    "chardet": "^2.1.0",
-    "iconv-lite": "^0.6.3",
-    "@vercel/blob": "^1.0.1",
     "@supabase/supabase-js": "^2.49.4",
-    "subtitle-converter": "^3.0.12",
-    "subsrt": "^1.1.1",
-    "sanitize-html": "^2.17.0",
+    "@vercel/blob": "^1.0.1",
+    "axios": "^1.9.0",
+    "chardet": "^2.1.0",
     "dotenv": "^17.2.3",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "franc": "^6.2.0",
+    "franc-all": "^7.2.0",
+    "iconv-lite": "^0.6.3",
+    "iso-639-3": "^3.0.1",
+    "pako": "^2.1.0",
+    "sanitize-html": "^2.17.0",
+    "srt-parser-2": "^1.2.3",
+    "stremio-addon-sdk": "^1.6.10",
+    "subsrt": "^1.1.1",
+    "subtitle-converter": "^3.0.12"
   },
   "engines": {
     "node": ">=14"

--- a/test/encoding.test.js
+++ b/test/encoding.test.js
@@ -104,11 +104,18 @@ async function runTests() {
             const languageMatch = sub.filename.match(/^([a-z]{2,3})_/);
             const languageHint = languageMatch ? languageMatch[1] : null;
 
-            // Decode with skipLanguageValidation to always get text (even if wrong language)
-            const decoded = decodeSubtitleBuffer(buffer, languageHint, { skipLanguageValidation: true });
-
             // File identifier for output (includes movie ID for clarity)
             const fileId = `${movie.id}/${sub.filename}`;
+
+            // Check if this language code should be skipped entirely
+            if (languageHint && SKIP_LANGUAGE_CODES.includes(languageHint.toLowerCase())) {
+                console.log(`  SKIPPED: ${fileId} (${sub.language}) - language code '${languageHint}' in skip list`);
+                totalSkipped++;
+                continue;
+            }
+
+            // Decode with skipLanguageValidation to always get text (even if wrong language)
+            const decoded = decodeSubtitleBuffer(buffer, languageHint, { skipLanguageValidation: true });
 
             // Check if this is a known bad input first (by hash)
             const knownBadEntry = isKnownBad(filepath);

--- a/test/known-bad-inputs.json
+++ b/test/known-bad-inputs.json
@@ -30,6 +30,36 @@
       "reason": "Source file corruption: 14,751 UTF-8 replacement characters (U+FFFD) baked into raw bytes from OpenSubtitles - encoding beyond repair",
       "markedAt": "2025-12-07T20:33:37.278Z",
       "originalFile": "tt0133093/tha_2_opensubtitles.raw"
+    },
+    "462944a98fda3365aeb09780f566b41f6b9b2b95005100de4972733faa450a34": {
+      "reason": "Source file corruption: Hebrew UTF-8 bytes where Thai expected, 18,697 replacement chars - original TIS-620 Thai encoding was destroyed during upload to OpenSubtitles",
+      "markedAt": "2025-12-08T23:46:35.293Z",
+      "originalFile": "tt4154796/tha_1_opensubtitles.raw"
+    },
+    "10ccc788674debfb6e85d06839cb62d0bc12cfab3346f262a0728a75b8bd400c": {
+      "reason": "Source file corruption: 686 UTF-8 replacement characters (U+FFFD) baked into source bytes from OpenSubtitles - encoding beyond repair",
+      "markedAt": "2025-12-08T23:46:36.528Z",
+      "originalFile": "tt0088323/fas_1_opensubtitles.raw"
+    },
+    "3a27cf9a2af3c9f02b2d1d06f7f9cec2c901359a9a44706bc57d7f24876683b0": {
+      "reason": "Source file corruption: Hebrew UTF-8 bytes where Thai expected, 7,959 replacement chars - original TIS-620 Thai encoding was destroyed during upload to OpenSubtitles",
+      "markedAt": "2025-12-08T23:46:37.753Z",
+      "originalFile": "tt0088323/tha_1_opensubtitles.raw"
+    },
+    "a6825bf8cbb2a0a84f68040468468f98b1be130bc52ba39dfb6f03791626bf54": {
+      "reason": "Source file corruption: Hebrew UTF-8 bytes where Thai expected, 12,573 replacement chars - original TIS-620 Thai encoding was destroyed during upload to OpenSubtitles",
+      "markedAt": "2025-12-08T23:46:39.290Z",
+      "originalFile": "tt0086190/tha_2_opensubtitles.raw"
+    },
+    "54b9dd713e593579b50c94ca1ea70e87271446611ae5d02ddc81a8f2c3043d6b": {
+      "reason": "Source file corruption: Hebrew UTF-8 bytes where Thai expected, 21,267 replacement chars - original TIS-620 Thai encoding was destroyed during upload to OpenSubtitles",
+      "markedAt": "2025-12-08T23:46:41.344Z",
+      "originalFile": "tt0114558/tha_1_opensubtitles.raw"
+    },
+    "5a042f41ed460371a2908dfdc0fd91d10e9d3fa1037dad587697b3f988409c91": {
+      "reason": "Source file corruption: Empty subtitle file - 22,276 lines of timestamp skeletons with no actual text content",
+      "markedAt": "2025-12-09T01:56:46.196Z",
+      "originalFile": "tt0133093/bul_1_opensubtitles.raw"
     }
   }
 }

--- a/test/movies.js
+++ b/test/movies.js
@@ -188,5 +188,41 @@ module.exports = [
             'fi': ['Stark', 'Talvi', 'tulee', 'Kuningas'],
             'hi': ['स्टार्क', 'सर्दी', 'आ', 'रही', 'राजा'],
         }
+    },
+    // === MISLABELED TEST CASES ===
+    // These movies have known mislabeled subtitles to verify MISLABELED detection works
+    {
+        id: 'tt0088323',
+        name: 'The NeverEnding Story',
+        expectedStrings: {
+            'en': ['Bastian', 'Nothing', 'Atreyu', 'book'],
+            'hu': ['Bastian', 'Semmi', 'Atreju'],  // Should fail - file is mislabeled
+        }
+    },
+    {
+        id: 'tt0116839',
+        name: 'Lawnmower Man 2: Beyond Cyberspace',
+        expectedStrings: {
+            'en': ['Jobe', 'cyberspace', 'virtual'],
+            'pl': ['Jobe', 'jest', 'nie'],  // Should fail - file is mislabeled
+        }
+    },
+    // === ORIGINAL THAI ENCODING TEST CASES ===
+    // These were the original movies that triggered the Thai encoding fix project
+    {
+        id: 'tt0086190',
+        name: 'Star Wars: Episode VI - Return of the Jedi',
+        expectedStrings: {
+            'en': ['Luke', 'Vader', 'Jedi', 'Force'],
+            'th': ['ลุค', 'เวเดอร์', 'เจได'],  // Thai script validation
+        }
+    },
+    {
+        id: 'tt0114558',
+        name: 'Strange Days',
+        expectedStrings: {
+            'en': ['Lenny', 'Macy', 'Faith'],
+            'th': ['เลนนี่', 'เมซี่'],  // Thai script validation
+        }
     }
 ];

--- a/test/movies.js
+++ b/test/movies.js
@@ -196,6 +196,9 @@ module.exports = [
         name: 'The NeverEnding Story',
         expectedStrings: {
             'en': ['Bastian', 'Nothing', 'Atreyu', 'book'],
+            'es': ['Atreyu', 'Bastian', 'está', 'qué'],
+            'pt': ['Bastian', 'Atreyu', 'você', 'não'],
+            'fr': ['Atreyu', 'Bastian', 'vous', 'pas'],
             'hu': ['Bastian', 'Semmi', 'Atreju'],  // Should fail - file is mislabeled
         }
     },
@@ -204,6 +207,9 @@ module.exports = [
         name: 'Lawnmower Man 2: Beyond Cyberspace',
         expectedStrings: {
             'en': ['Jobe', 'cyberspace', 'virtual'],
+            'ru': ['Джоб', 'это', 'что', 'мой'],
+            'es': ['Jobe', 'esto', 'qué', 'para'],
+            'el': ['Τρέις', 'είναι', 'για', 'αυτό'],
             'pl': ['Jobe', 'jest', 'nie'],  // Should fail - file is mislabeled
         }
     },
@@ -214,6 +220,9 @@ module.exports = [
         name: 'Star Wars: Episode VI - Return of the Jedi',
         expectedStrings: {
             'en': ['Luke', 'Vader', 'Jedi', 'Force'],
+            'zh': ['維達', '路克', '絕地', '天行者'],
+            'ru': ['Люк', 'Соло', 'Скайуокер', 'галактик'],
+            'ja': ['ルーク', 'ソロ', 'ジェダイ', 'スカイウォーカー'],
             'th': ['ลุค', 'เวเดอร์', 'เจได'],  // Thai script validation
         }
     },
@@ -222,6 +231,9 @@ module.exports = [
         name: 'Strange Days',
         expectedStrings: {
             'en': ['Lenny', 'Macy', 'Faith'],
+            'es': ['Lenny', 'esto', 'qué', 'para'],
+            'pt': ['Lenny', 'Faith', 'isso', 'você'],
+            'fr': ['Lenny', 'Faith', 'vous', 'pas'],
             'th': ['เลนนี่', 'เมซี่'],  // Thai script validation
         }
     }


### PR DESCRIPTION
> This is the result of another evening watching movies and seeing garbage in one of the language fields. The end goal is that Strelingo should serve up perfectly encoded subtitles in the exact language you requested, regardless of the quality of the source subtitles 😁

Verify that the decoded language is the one we expect before merging

Previously we were doing lots of decoding testing in the test suite, and detecting problems and reporting on them. But we were not doing that on the live site when users were requesting translations. As a result, we'd fairly commonly download subtitles and merge them together, even if the decoding function failed to properly decode the correct language. This patch goes about it a little smarter:

- After decoding the subtitles, check that the results contain the language expected.
- Use the [franc-all](https://github.com/wooorm/franc/tree/main) library for language detection, which is far more accurate than just checking the character set.
- If the detected language doesn't match the requested language then we discard the input (it was either corrupted and cannot be decoded, or it was labeled as the wrong language) we return NULL, which bumps us on to the next subtitle file to attempt it instead.

Test suite improvements:
- Added `detectLanguage()` function to identify actual language of content
- Added `skipLanguageValidation` option to decodeSubtitleBuffer() for test analysis
- Updated test to distinguish MISLABELED (wrong language) from FAIL (encoding error)

New test movies added:
- tt0088323 (The NeverEnding Story) - has mislabeled Hungarian subtitle
- tt0116839 (Lawnmower Man 2) - has mislabeled Polish subtitle
- tt0086190 (Star Wars: Return of the Jedi) - original encoding test case
- tt0114558 (Strange Days) - original encoding test case

Test output now shows:
- PASS: Content matches expected language
- MISLABELED: Content decoded OK but is wrong language (with detected language)
- FAIL: Actual encoding failure (replacement chars, etc.)
- KNOWN BAD: Previously identified corrupt files