### PR TITLE
Minor docker-compose.yml fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,23 +5,16 @@ services:
     restart: unless-stopped
     ports:
       - "7000:7000"
-    environment:
-      # Choose ONE storage backend:
 
-      # Option 1: Vercel Blob Storage
-      - BLOB_READ_WRITE_TOKEN=${BLOB_READ_WRITE_TOKEN:-}
-      - SKIP_VERCEL_BLOB=${SKIP_VERCEL_BLOB:-}
+    # See .env for configurable settings
+    env_file:
+      - .env
 
-      # Option 2: Supabase Storage
-      - SUPABASE_URL=${SUPABASE_URL:-}
-      - SUPABASE_SERVICE_KEY=${SUPABASE_SERVICE_KEY:-}
+    # If you use local file storage (Option 3) and want to store the cached subtitles on your
+    # host instead of inside the container, uncomment the next two lines:
+    # volumes:
+    #   - ./data:/app/subtitles
 
-      # Option 3: Local File Storage (self-hosted)
-      - LOCAL_STORAGE_DIR=${LOCAL_STORAGE_DIR:-}
-      - EXTERNAL_URL=${EXTERNAL_URL:-}
-    volumes:
-      # Uncomment to use local file storage (Option 3)
-      # - ./data:/app/subtitles
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:7000/manifest.json"]
       interval: 30s


### PR DESCRIPTION
Instead of re-defining all the ENV vars in the docker compose file, just reference the .env file, which has all the info (one source of truth)