### PR TITLE
Fix Node runtime cache writes and external subtitle URLs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -325,6 +325,14 @@ function getEnvVar(c: any, key: string): string | undefined {
     return c.env?.[key] || (typeof process !== 'undefined' && process.env ? process.env[key] : undefined);
 }
 
+function getOptionalExecutionCtx(c: any): any | undefined {
+    try {
+        return c.executionCtx;
+    } catch {
+        return undefined;
+    }
+}
+
 function extractBrowserLanguageFromHeader(acceptLanguageHeader: string | null): string {
     if (!acceptLanguageHeader) {
         return 'eng';
@@ -1360,7 +1368,7 @@ async function handleSubtitlesRequest(c: any) {
     if (mainLang === transLang) {
         console.log(`Error: Main language (${mainLang}) and Translation language (${transLang}) cannot be the same. Aborting.`);
         const res = c.json({ subtitles: [], cacheMaxAge: 3600 }, 200, { 'Cache-Control': 'public, max-age=3600' });
-        putCachedResponse(cacheKey, res, c.executionCtx);
+        putCachedResponse(cacheKey, res, getOptionalExecutionCtx(c));
         return res;
     }
 
@@ -1380,7 +1388,7 @@ async function handleSubtitlesRequest(c: any) {
     if (!imdbId || !imdbId.startsWith('tt')) {
         console.log('No valid IMDB ID provided');
         const res = c.json({ subtitles: [] }, 200, { 'Cache-Control': 'public, max-age=60' });
-        putCachedResponse(cacheKey, res, c.executionCtx);
+        putCachedResponse(cacheKey, res, getOptionalExecutionCtx(c));
         return res;
     }
 
@@ -1428,7 +1436,7 @@ async function handleSubtitlesRequest(c: any) {
         if (!allSubtitles) {
             console.log('Failed to fetch subtitles.');
             const res = c.json({ subtitles: [], cacheMaxAge: 60 }, 200, { 'Cache-Control': 'public, max-age=60' });
-            putCachedResponse(cacheKey, res, c.executionCtx);
+            putCachedResponse(cacheKey, res, getOptionalExecutionCtx(c));
             return res;
         }
 
@@ -1441,14 +1449,14 @@ async function handleSubtitlesRequest(c: any) {
         if (!mainSubInfoList || mainSubInfoList.length === 0) {
             console.log(`No main language (${mainLang}) subtitles found.`);
             const res = c.json({ subtitles: [], cacheMaxAge: 60 }, 200, { 'Cache-Control': 'public, max-age=60' });
-            putCachedResponse(cacheKey, res, c.executionCtx);
+            putCachedResponse(cacheKey, res, getOptionalExecutionCtx(c));
             return res;
         }
 
         if (!transSubInfoList || transSubInfoList.length === 0) {
             console.warn(`No translation language (${transLang}) subtitles found.`);
             const res = c.json({ subtitles: [], cacheMaxAge: 60 }, 200, { 'Cache-Control': 'public, max-age=60' });
-            putCachedResponse(cacheKey, res, c.executionCtx);
+            putCachedResponse(cacheKey, res, getOptionalExecutionCtx(c));
             return res;
         }
 
@@ -1500,14 +1508,14 @@ async function handleSubtitlesRequest(c: any) {
         if (!selectedMainSubInfo) {
             console.error("Failed to fetch and parse any of the available main subtitles. Cannot proceed.");
             const res = c.json({ subtitles: [], cacheMaxAge: 60 }, 200, { 'Cache-Control': 'public, max-age=60' });
-            putCachedResponse(cacheKey, res, c.executionCtx);
+            putCachedResponse(cacheKey, res, getOptionalExecutionCtx(c));
             return res;
         }
 
         if (!lazyServingEnabled && !mainParsed) {
             console.error("Failed to parse any of the available main subtitles. Cannot proceed.");
             const res = c.json({ subtitles: [], cacheMaxAge: 60 }, 200, { 'Cache-Control': 'public, max-age=60' });
-            putCachedResponse(cacheKey, res, c.executionCtx);
+            putCachedResponse(cacheKey, res, getOptionalExecutionCtx(c));
             return res;
         }
 
@@ -1530,7 +1538,7 @@ async function handleSubtitlesRequest(c: any) {
 
             if (lazyServingEnabled) {
                 console.log(`Generating signed lazy subtitle URL for v${version}...`);
-                const workerUrl = `${new URL(c.req.url).protocol}//${new URL(c.req.url).host}`;
+                const workerUrl = (getEnvVar(c, 'EXTERNAL_URL') || `${new URL(c.req.url).protocol}//${new URL(c.req.url).host}`).replace(/\/+$/g, '');
 
                 const paramsObj = {
                     mainUrl: selectedMainSubInfo.url,
@@ -1619,13 +1627,13 @@ async function handleSubtitlesRequest(c: any) {
         }, 200, {
             'Cache-Control': 'public, max-age=21600, s-maxage=21600, stale-while-revalidate=86400',
         });
-        putCachedResponse(cacheKey, successResponse, c.executionCtx);
+        putCachedResponse(cacheKey, successResponse, getOptionalExecutionCtx(c));
         return successResponse;
 
     } catch (e: any) {
         console.error('Error in subtitle handler:', e.message);
         const res = c.json({ subtitles: [], cacheMaxAge: 60 }, 200, { 'Cache-Control': 'public, max-age=60' });
-        putCachedResponse(cacheKey, res, c.executionCtx);
+        putCachedResponse(cacheKey, res, getOptionalExecutionCtx(c));
         return res;
     }
 }
@@ -1671,7 +1679,7 @@ app.get('/serve-subtitles/:token/:filename', async (c) => {
             'Cache-Control': 'public, max-age=86400'
         });
 
-        putCachedResponse(cacheKey, response, c.executionCtx);
+        putCachedResponse(cacheKey, response, getOptionalExecutionCtx(c));
 
         return response;
 


### PR DESCRIPTION
## Summary

Fixes two self-hosted Docker/Node runtime issues:

- Avoids direct `c.executionCtx` access at cache-write call sites. In Hono's Node runtime this getter can throw `This context has no ExecutionContext`, which breaks configured subtitle requests even though cache writes are optional.
- Uses `EXTERNAL_URL` as the preferred base for lazy `/serve-subtitles/...` URLs. This keeps generated subtitle URLs HTTPS/canonical when the addon runs behind a TLS-terminating reverse proxy.

## Details

- Added `getOptionalExecutionCtx(c)` to safely return the Worker execution context when available and `undefined` otherwise.
- Updated all `putCachedResponse(...)` call sites to use that helper, preserving Worker `waitUntil` behavior while allowing Node to fall back to the existing fire-and-forget cache write path.
- Updated lazy subtitle URL generation to prefer `EXTERNAL_URL`, trimming trailing slashes before appending `/serve-subtitles/...`.

## Verification

Validated against a self-hosted Docker/Kubernetes deployment:

- Before the fix, configured subtitle requests found subtitles and then failed with `This context has no ExecutionContext`.
- After the fix, a configured request for `movie/tt0111161` returned HTTP 200 with an `English+French` subtitle entry.
- The returned subtitle URL used `https://strelingo.nilluv.com/...` from `EXTERNAL_URL`.
- Fetching the generated `/serve-subtitles/...srt` URL returned HTTP 200 and a merged SRT file.

Static checks:

- `git diff --check` passed.

Not run locally:

- `npm test` / `npm run build` because dependencies were not installed in the temporary checkout.
